### PR TITLE
Set Pymol to export backwards-compatible PSE files.

### DIFF
--- a/eppic-cli/src/main/java/eppic/PymolRunner.java
+++ b/eppic-cli/src/main/java/eppic/PymolRunner.java
@@ -298,6 +298,7 @@ public class PymolRunner {
 		
 		pymolScriptBuilder.append("@ "+pmlFile+";");
 		
+		pymolScriptBuilder.append("set pse_export_version, 1.5");
 		pymolScriptBuilder.append("save "+pseFile+";");
 
 		
@@ -481,6 +482,7 @@ public class PymolRunner {
 		
 		pymolScriptBuilder.append("@ "+pmlFile+";");
 		
+		pymolScriptBuilder.append("set pse_export_version, 1.5");
 		pymolScriptBuilder.append("save "+pseFile+";");
 		
 		// writing finally the icon png (we don't need this in pml)


### PR DESCRIPTION
Should fix #62 in combination with upgrading pymol to 1.7.6 or newer