### PR TITLE
Support for setting PDB_DIR through the system property

### DIFF
--- a/eppic-cli/src/main/java/eppic/EppicParams.java
+++ b/eppic-cli/src/main/java/eppic/EppicParams.java
@@ -533,22 +533,28 @@ public class EppicParams {
 		
 		if (!isInputAFile()) {
 			
+			// Search the ATOM_CACHE_PATH in the config file
 			if (atomCachePath!=null && ! new File(atomCachePath).isDirectory()) {
 				throw new EppicException(null, "ATOM_CACHE_PATH wasn't set to a valid directory."
 						+ " For -i option to work with PDB codes as input, you must set ATOM_CACHE_PATH to "
 						+ "a directory where the mmCIF files will be cached with same layout as PDB ftp."
-						+ " You can also set it through environment variable PDB_DIR. ", true);
+						+ " You can also set it through environment variable or System property PDB_DIR. ", true);
 			}
 			
+			// Check the PDB_DIR in the environment
 			Map<String,String> env = System.getenv();
 
 			if( env.containsKey(UserConfiguration.PDB_DIR) && !env.get(UserConfiguration.PDB_DIR).trim().isEmpty()) {
 				LOGGER.info("Detected PDB_DIR environment variable with dir {}", env.get(UserConfiguration.PDB_DIR));
 			} else {
-
-				if (atomCachePath==null || ! new File(atomCachePath).isDirectory()) {
+				
+				// Check the PDB_DIR in the System properties
+				if (System.getProperty(UserConfiguration.PDB_DIR) != null && !System.getProperty(UserConfiguration.PDB_DIR).trim().isEmpty()){
+					LOGGER.info("Detected PDB_DIR System property with dir {}", System.getProperty(UserConfiguration.PDB_DIR));
+				}
+				else if (atomCachePath==null || ! new File(atomCachePath).isDirectory()) {
 					throw new EppicException(null,
-							"To be able to use PDB codes as input with -i option, a valid ATOM_CACHE_PATH must be set in config file, or through environment variable PDB_DIR. " +
+							"To be able to use PDB codes as input with -i option, a valid ATOM_CACHE_PATH must be set in config file or through environment variable or System property PDB_DIR. " +
 							"It must contain the PDB mmCIF gzip file repository in same divided layout as PDB ftp.", true);
 				}
 			}


### PR DESCRIPTION
Fix #108 

How should we resolve when the user sets the variable in more than one place differently. For example, when **ATOM_CACHE_PATH** and the environment **PDB_DIR** variable are set to different directories. I think that now the environment variable has preference, but I am not completely sure. 
Can this be an issue?