### PR TITLE
Generate assembly diagram thumbnails with graphviz

### DIFF
--- a/eppic-cli/README.md
+++ b/eppic-cli/README.md
@@ -118,8 +118,8 @@ Linux or downloading java from http://java.com/en/download/index.jsp
      - CLUSTALO_BIN or TCOFFEE_BIN
    
      to their appropriate paths. 
-     Optionally you can also set PYMOL_EXE (needed for -l option) and 
-     LOCAL_CIF_DIR (needed to provide PDB codes with -i). 
+     Optionally you can also set PYMOL_EXE and GRAPHVIZ_EXE (needed for
+     -l option) and LOCAL_CIF_DIR (needed to provide PDB codes with -i). 
 
 
 3. Now you can run eppic:

--- a/eppic-cli/eppic.conf
+++ b/eppic-cli/eppic.conf
@@ -31,6 +31,9 @@ CLUSTALO_BIN=/usr/bin/clustalo
 # PyMOL version must be 1.5+ (needs to support reading of pdb.gz files)
 PYMOL_EXE=/usr/bin/pymol
 
+# Path to the Graphviz dot command (needed for option -l only)
+GRAPHVIZ_EXE=/usr/bin/dot
+
 # Passing PDB codes with -i will only work if these parameters are set
 # Path where mmCIF files will be cached locally,
 # can also be set through environment variable PDB_DIR. The layout of the

--- a/eppic-cli/scripts/precomp-pipeline/stepC-run_eppic/eppic.conf
+++ b/eppic-cli/scripts/precomp-pipeline/stepC-run_eppic/eppic.conf
@@ -39,6 +39,7 @@ BLAST_CACHE_DIR=/gpfs/home/duarte_j/data/blast_cache/uniprot_2013_02
 
 
 PYMOL_EXE=/gpfs/home/duarte_j/software/bin/pymol
+GRAPHVIZ_EXE=/gpfs/home/duarte_j/software/bin/dot
 
 LOCAL_UNIPROT_DB_NAME=uniprot_2013_02
 LOCAL_TAXONOMY_DB_NAME=uniprot_taxonomy

--- a/eppic-cli/src/main/java/eppic/EppicParams.java
+++ b/eppic-cli/src/main/java/eppic/EppicParams.java
@@ -142,7 +142,10 @@ public class EppicParams {
 	
 	// default pymol exec
 	private static final File	  DEF_PYMOL_EXE = new File("/usr/bin/pymol");
-	
+
+	// default graphviz exec
+	private static final File	  DEF_GRAPHVIZ_EXE = new File("/usr/bin/dot");
+
 	// default hbplus exec
 	private static final File     DEF_HBPLUS_EXE = new File("/usr/bin/hbplus");
 	
@@ -247,6 +250,7 @@ public class EppicParams {
 	private File	 clustaloBin;
 	
 	private File	 pymolExe;
+	private File	 graphvizExe;
 
 	private AAAlphabet alphabet;
 
@@ -605,7 +609,10 @@ public class EppicParams {
 			if (!pymolExe.exists()) {
 				throw new EppicException(null, "PYMOL_EXE must be set to a valid value in config file.", true);
 			}
-			
+			if (!graphvizExe.exists()) {
+				throw new EppicException(null, "GRAPHVIZ_EXE must be set to a valid value in config file.", true);
+			}
+
 		}
 		
 		if (alphabet == null) {
@@ -871,6 +878,8 @@ public class EppicParams {
 			
 			pymolExe		= new File(p.getProperty("PYMOL_EXE", DEF_PYMOL_EXE.toString()));
 			
+			graphvizExe		= new File(p.getProperty("GRAPHVIZ_EXE", DEF_GRAPHVIZ_EXE.toString()));
+			
 			hbplusExe       = new File(p.getProperty("HBPLUS_EXE", DEF_HBPLUS_EXE.toString()));
 			
 			nSpherePointsASAcalc = Integer.parseInt(p.getProperty("NSPHEREPOINTS_ASA_CALC", new Integer(DEF_NSPHEREPOINTS_ASA_CALC).toString()));
@@ -944,6 +953,10 @@ public class EppicParams {
 
 	public File getPymolExe() {
 		return pymolExe;
+	}
+	
+	public File getGraphvizExe() {
+		return graphvizExe;
 	}
 	
 	public File getHbplusExe() {

--- a/eppic-cli/src/main/java/eppic/GraphvizRunner.java
+++ b/eppic-cli/src/main/java/eppic/GraphvizRunner.java
@@ -1,0 +1,91 @@
+package eppic;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import eppic.assembly.gui.LatticeGUIMustache;
+
+
+public class GraphvizRunner {	
+	private File graphvizExec;
+	
+	public GraphvizRunner(File graphvizExec) {
+		this.graphvizExec = graphvizExec;
+	}
+	
+	/**
+	 * Runs graphviz on the specified dotfile
+	 * 
+	 * @param dotFile Input dot file
+	 * @param outfile output filename
+	 * @param format output format (png, svg, etc.)
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	public void generateFromDot(File dotFile, File outfile, String format)
+	throws IOException, InterruptedException {
+		List<String> command = new ArrayList<String>();
+		command.add(graphvizExec.getAbsolutePath());
+		command.add("-Kneato");
+		command.add("-n2");
+		command.add("-T");
+		command.add(format);
+		command.add("-o");
+		command.add(outfile.toString());
+		command.add(dotFile.toString());
+
+		Process process = new ProcessBuilder(command).start();
+		boolean done = process.waitFor(60,TimeUnit.SECONDS);
+		
+		if (!done) {
+			throw new IOException("Graphviz execution timed out.");
+		}
+		if (process.exitValue()!=0) {
+			throw new IOException("Graphviz exited with error status "+process.exitValue());
+		}
+	}
+	
+	/**
+	 * Runs graphviz on the output of executing the specified GUI, which
+	 * should produce dot output.
+	 * 
+	 * This avoids writing the dot file to disk.
+	 * 
+	 * @param dotFile Input dot file
+	 * @param outfile output filename
+	 * @param format output format (png, svg, etc.)
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	public void generateFromDot(LatticeGUIMustache gui, File outfile, String format)
+	throws IOException, InterruptedException {
+		List<String> command = new ArrayList<String>();
+		command.add(graphvizExec.getAbsolutePath());
+		command.add("-Kneato");
+		command.add("-n2");
+		command.add("-T");
+		command.add(format);
+		command.add("-o");
+		command.add(outfile.toString());
+
+		Process process = new ProcessBuilder(command).start();
+		OutputStream dotIn = process.getOutputStream();
+		try( PrintWriter writer = new PrintWriter(dotIn) ){
+			gui.execute(writer);
+		}
+		
+		boolean done = process.waitFor(10,TimeUnit.SECONDS);
+		
+		if (!done) {
+			throw new IOException("Graphviz execution timed out.");
+		}
+		if (process.exitValue()!=0) {
+			throw new IOException("Graphviz exited with error status "+process.exitValue());
+		}
+	}
+}

--- a/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI3Dmol.java
+++ b/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI3Dmol.java
@@ -16,6 +16,8 @@ import org.biojava.nbio.structure.io.util.FileDownloadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import eppic.assembly.LatticeGraph3D;
+
 /**
  * 3Dmol viewer for LatticeGraph.
  * 
@@ -50,6 +52,10 @@ public class LatticeGUI3Dmol extends LatticeGUIMustache {
 	}
 	public LatticeGUI3Dmol(String template, Structure struc,String strucURI,Collection<Integer> interfaceIds) throws StructureException {
 		this(template,struc,strucURI,interfaceIds,null);
+	}
+	public LatticeGUI3Dmol(String template, LatticeGraph3D graph, String strucURI) throws StructureException {
+		super(template, graph);
+		this.strucURI = strucURI;
 	}
 	public LatticeGUI3Dmol(String template, Structure struc,String strucURI,Collection<Integer> interfaceIds,List<StructureInterface> allInterfaces) throws StructureException {
 		super(template, struc,interfaceIds, allInterfaces);


### PR DESCRIPTION
- Running with -l generates both the structure thumbnails (with PyMOL)
  and the assembly diagram thumbnails (with Graphviz)
- Add GRAPHVIZ_EXEC parameter in .eppic.conf for the `dot` command
  (required for -l)
- Add GraphvizRunner for calling the subprocess