### PR TITLE
Expanding unit cell on client

### DIFF
--- a/eppic-cli/pom.xml
+++ b/eppic-cli/pom.xml
@@ -9,7 +9,7 @@
         <artifactId>eppic-cli</artifactId>
 
 	<properties>
-		<biojava.version>4.2.3-SNAPSHOT</biojava.version>
+		<biojava.version>4.2.2</biojava.version>
 	</properties>
 	
 	<repositories>

--- a/eppic-cli/pom.xml
+++ b/eppic-cli/pom.xml
@@ -9,7 +9,7 @@
         <artifactId>eppic-cli</artifactId>
 
 	<properties>
-		<biojava.version>4.2.2</biojava.version>
+		<biojava.version>4.2.3-SNAPSHOT</biojava.version>
 	</properties>
 	
 	<repositories>

--- a/eppic-cli/src/main/java/eppic/assembly/Assembly.java
+++ b/eppic-cli/src/main/java/eppic/assembly/Assembly.java
@@ -39,7 +39,6 @@ import org.biojava.nbio.structure.contact.StructureInterfaceCluster;
 import org.biojava.nbio.structure.io.FileConvert;
 import org.biojava.nbio.structure.io.mmcif.MMCIFFileTools;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
-import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.biojava.nbio.structure.symmetry.core.AxisAligner;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryDetector;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryParameters;
@@ -864,7 +863,7 @@ public class Assembly {
 
 		ps.print(FileConvert.getAtomSiteHeader());
 
-		List<AtomSite> atomSites = new ArrayList<>();
+		List<Object> atomSites = new ArrayList<>();
 
 		int atomId = 1;
 		for (ChainVertex cv:structure) {
@@ -893,7 +892,7 @@ public class Assembly {
 			}
 		}
 
-		ps.print(MMCIFFileTools.toMMCIF(atomSites, AtomSite.class));
+		ps.print(MMCIFFileTools.toMMCIF(atomSites));
 
 
 		ps.close();

--- a/eppic-cli/src/main/java/eppic/assembly/Assembly.java
+++ b/eppic-cli/src/main/java/eppic/assembly/Assembly.java
@@ -39,6 +39,7 @@ import org.biojava.nbio.structure.contact.StructureInterfaceCluster;
 import org.biojava.nbio.structure.io.FileConvert;
 import org.biojava.nbio.structure.io.mmcif.MMCIFFileTools;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
+import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.biojava.nbio.structure.symmetry.core.AxisAligner;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryDetector;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryParameters;
@@ -623,6 +624,8 @@ public class Assembly {
 		}
 		return chains;
 	}
+	
+	@SuppressWarnings("unused")
 	private static void transformChainsInPlace(Map<ChainVertex, Point3i> placements,
 			Structure structure, LatticeGraph<ChainVertex, InterfaceEdge> latticeGraph,
 			CrystalCell cell)
@@ -861,7 +864,7 @@ public class Assembly {
 
 		ps.print(FileConvert.getAtomSiteHeader());
 
-		List<Object> atomSites = new ArrayList<Object>();
+		List<AtomSite> atomSites = new ArrayList<>();
 
 		int atomId = 1;
 		for (ChainVertex cv:structure) {
@@ -890,7 +893,7 @@ public class Assembly {
 			}
 		}
 
-		ps.print(MMCIFFileTools.toMMCIF(atomSites));
+		ps.print(MMCIFFileTools.toMMCIF(atomSites, AtomSite.class));
 
 
 		ps.close();

--- a/eppic-cli/src/main/java/eppic/assembly/LatticeGraph.java
+++ b/eppic-cli/src/main/java/eppic/assembly/LatticeGraph.java
@@ -74,7 +74,6 @@ public class LatticeGraph<V extends ChainVertex,E extends InterfaceEdge> {
 	// currently exposed graph
 	private UndirectedGraph<V,E> subgraph;
 
-
 	private boolean globalReferencePoint;
 	private Map<String,Matrix4d[]> unitCellOperators = new HashMap<>(); // In crystal coordinates
 	private Map<String,Point3d> referencePoints = new HashMap<>(); // Chain ID -> centroid coordinate

--- a/eppic-cli/src/main/java/eppic/assembly/LatticeGraph3D.java
+++ b/eppic-cli/src/main/java/eppic/assembly/LatticeGraph3D.java
@@ -30,7 +30,6 @@ import org.biojava.nbio.structure.contact.StructureInterface;
 import org.biojava.nbio.structure.io.FileConvert;
 import org.biojava.nbio.structure.io.mmcif.MMCIFFileTools;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
-import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.biojava.nbio.structure.xtal.CrystalCell;
 import org.biojava.nbio.structure.xtal.CrystalTransform;
 import org.jcolorbrewer.ColorBrewer;
@@ -441,7 +440,7 @@ public class LatticeGraph3D extends LatticeGraph<ChainVertex3D,InterfaceEdge3D> 
 
 		out.print(FileConvert.getAtomSiteHeader());
 
-		List<AtomSite> atomSites = new ArrayList<>();
+		List<Object> atomSites = new ArrayList<>();
 
 		int atomId = 1;
 		for (ChainVertex3D cv:getGraph().vertexSet()) {
@@ -476,7 +475,7 @@ public class LatticeGraph3D extends LatticeGraph<ChainVertex3D,InterfaceEdge3D> 
 			}
 		}
 
-		out.print(MMCIFFileTools.toMMCIF(atomSites, AtomSite.class));
+		out.print(MMCIFFileTools.toMMCIF(atomSites));
 
 
 		out.close();

--- a/eppic-cli/src/main/java/eppic/assembly/LatticeGraph3D.java
+++ b/eppic-cli/src/main/java/eppic/assembly/LatticeGraph3D.java
@@ -30,6 +30,7 @@ import org.biojava.nbio.structure.contact.StructureInterface;
 import org.biojava.nbio.structure.io.FileConvert;
 import org.biojava.nbio.structure.io.mmcif.MMCIFFileTools;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
+import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.biojava.nbio.structure.xtal.CrystalCell;
 import org.biojava.nbio.structure.xtal.CrystalTransform;
 import org.jcolorbrewer.ColorBrewer;
@@ -55,6 +56,7 @@ public class LatticeGraph3D extends LatticeGraph<ChainVertex3D,InterfaceEdge3D> 
 	private final Map<String,Point3d> chainCentroid;
 	
 	private final WrappingPolicy policy;
+		
 
 	/**
 	 * Create the graph after calculating the interfaces
@@ -398,14 +400,15 @@ public class LatticeGraph3D extends LatticeGraph<ChainVertex3D,InterfaceEdge3D> 
 
 
 	/**
-	 * Writes this Assembly to mmCIF file (gzipped) with chain ids as follows:
+	 * Writes to given PrintWriter the whole unit cell in mmCIF format, with chain ids as follows:
 	 *  <li> author_ids: chainId_operatorId</li>
 	 *  <li> asym_ids: chainId_operatorId</li>
-	 * The atom ids will be renumbered if the Assembly contains symmetry-related molecules,
-	 * otherwise some molecular viewers (e.g. 3Dmol.js) won't be able to read the atoms
+	 * The atom ids are renumbered, so that symmetry partners don't repeat them.
+	 * Otherwise some molecular viewers (e.g. 3Dmol.js) won't be able to read the atoms
 	 * as distinct.
+	 * <p>
 	 * Note that PyMOL supports multi-letter chain ids only from 1.7.4
-	 * @param file
+	 * @param out the writer to write the mmCIF data to
 	 * @throws IOException
 	 * @throws StructureException
 	 */
@@ -438,13 +441,13 @@ public class LatticeGraph3D extends LatticeGraph<ChainVertex3D,InterfaceEdge3D> 
 
 		out.print(FileConvert.getAtomSiteHeader());
 
-		List<Object> atomSites = new ArrayList<Object>();
+		List<AtomSite> atomSites = new ArrayList<>();
 
 		int atomId = 1;
 		for (ChainVertex3D cv:getGraph().vertexSet()) {
 			String chainId = cv.getChain().getChainID()+"_"+cv.getOpId();
 			//TODO maybe need to clone and transform here?
-			Matrix4d m = getUnitCellTransformationOrthonormal(chainId, cv.getOpId());
+			Matrix4d m = getUnitCellTransformationOrthonormal(cv.getChain().getChainID(), cv.getOpId());
 			//Point3d refCoord = graph.getReferenceCoordinate(cv.getChainId());
 
 			Chain newChain = (Chain) cv.getChain().clone();
@@ -473,10 +476,26 @@ public class LatticeGraph3D extends LatticeGraph<ChainVertex3D,InterfaceEdge3D> 
 			}
 		}
 
-		out.print(MMCIFFileTools.toMMCIF(atomSites));
+		out.print(MMCIFFileTools.toMMCIF(atomSites, AtomSite.class));
 
 
 		out.close();
+	}
+	
+	/**
+	 * Returns a set of all unique transformations needed to create the unit cell (one per vertex in lattice graph).
+	 * @return
+	 * @throws StructureException if problems occur calculating centroids
+	 */
+	public Set<Matrix4d> getUnitCellTransforms() throws StructureException {
+		Set<Matrix4d> transforms = new HashSet<>();
+		for (ChainVertex3D cv:getGraph().vertexSet()) {
+			Matrix4d m = getUnitCellTransformationOrthonormal(cv.getChain().getChainID(), cv.getOpId());
+			
+			transforms.add(m);
+		}
+		
+		return transforms;
 	}
 	
 	/**

--- a/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI.java
+++ b/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI.java
@@ -723,7 +723,7 @@ public class LatticeGUI {
 	 * @param name
 	 * @return
 	 */
-	private static File getFile(AtomCache cache, String name) {
+	public static File getFile(AtomCache cache, String name) {
 		if(cache.isUseMmCif()) {
 			MMCIFFileReader reader = new MMCIFFileReader(cache.getPath());
 			reader.setFetchBehavior(cache.getFetchBehavior());

--- a/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI3Dmol.java
+++ b/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI3Dmol.java
@@ -32,7 +32,7 @@ public class LatticeGUI3Dmol extends LatticeGUIMustache {
 	private static final Logger logger = LoggerFactory.getLogger(LatticeGUI3Dmol.class);
 
 	static final String MUSTACHE_TEMPLATE_3DMOL = "mustache/eppic/assembly/gui/LatticeGUI3Dmol.html.mustache";
-	static final String DEFAULT_URL_3DMOL = "http://3Dmol.csb.pitt.edu/build/3Dmol-min.js";
+	static final String DEFAULT_URL_3DMOL = "https://cdn.rawgit.com/arose/ngl/v0.7.1a/js/build/ngl.embedded.min.js";
 	
 	private String strucURI;
 	private String url3Dmol = DEFAULT_URL_3DMOL;
@@ -160,7 +160,9 @@ public class LatticeGUI3Dmol extends LatticeGUIMustache {
 		LatticeGUI3Dmol gui = new LatticeGUI3Dmol(template, struc, uri, interfaceIds);
 
 		if(cifOut != null) {
-			gui.writeCIFfile(cifOut);
+			
+			cifOut.println(struc.toMMCIF());
+			//gui.writeCIFfile(cifOut);
 		}
 
 		gui.execute(htmlOut);

--- a/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI3Dmol.java
+++ b/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI3Dmol.java
@@ -163,6 +163,7 @@ public class LatticeGUI3Dmol extends LatticeGUIMustache {
 			
 			cifOut.println(struc.toMMCIF());
 			//gui.writeCIFfile(cifOut);
+			
 		}
 
 		gui.execute(htmlOut);

--- a/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI3Dmol.java
+++ b/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUI3Dmol.java
@@ -32,7 +32,7 @@ public class LatticeGUI3Dmol extends LatticeGUIMustache {
 	private static final Logger logger = LoggerFactory.getLogger(LatticeGUI3Dmol.class);
 
 	static final String MUSTACHE_TEMPLATE_3DMOL = "mustache/eppic/assembly/gui/LatticeGUI3Dmol.html.mustache";
-	static final String DEFAULT_URL_3DMOL = "https://cdn.rawgit.com/arose/ngl/v0.7.1a/js/build/ngl.embedded.min.js";
+	static final String DEFAULT_URL_3DMOL = "http://3Dmol.csb.pitt.edu/build/3Dmol-min.js";
 	
 	private String strucURI;
 	private String url3Dmol = DEFAULT_URL_3DMOL;

--- a/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUIJGraph.java
+++ b/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUIJGraph.java
@@ -27,7 +27,6 @@ import javax.vecmath.Point3d;
 
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
-import org.biojava.nbio.structure.StructureTools;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.symmetry.core.AxisAligner;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryResults;

--- a/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUIMustache.java
+++ b/eppic-cli/src/main/java/eppic/assembly/gui/LatticeGUIMustache.java
@@ -219,7 +219,9 @@ public class LatticeGUIMustache {
 			latticeGraph.filterEngagedInterfaces(interfaceIds);
 		}
 
-		pdbId = struc.getStructureIdentifier().toCanonical().getPdbId();
+		if (struc.getStructureIdentifier()!=null ) {
+			pdbId = struc.getStructureIdentifier().toCanonical().getPdbId();
+		}
 		if(pdbId == null || pdbId.length() != 4) {
 			pdbId = struc.getName();
 		}

--- a/eppic-cli/src/main/resources/mustache/eppic/assembly/gui/LatticeGUINgl.html.mustache
+++ b/eppic-cli/src/main/resources/mustache/eppic/assembly/gui/LatticeGUINgl.html.mustache
@@ -18,8 +18,8 @@
 
 		stage.loadFile( "{{strucURI}}", { defaultRepresentation: false } ).then(function(o) {
 			
-			//////// cartoon instead of ribbon ////////////////////////////////
-			o.addRepresentation( "cartoon", { opacity: 0.5, side: THREE.FrontSide } );
+			// show full unit cell
+			o.addRepresentation( "cartoon", { opacity: 0.5, side: THREE.FrontSide, assembly: "UNITCELL" } );
 			
 			////////  spheres  ///////////////////////////////////////////////
 			var spherePositions = [

--- a/eppic-cli/src/main/resources/mustache/eppic/assembly/gui/LatticeGUINgl.html.mustache
+++ b/eppic-cli/src/main/resources/mustache/eppic/assembly/gui/LatticeGUINgl.html.mustache
@@ -18,8 +18,32 @@
 
 		stage.loadFile( "{{strucURI}}", { defaultRepresentation: false } ).then(function(o) {
 			
-			// show full unit cell
-			o.addRepresentation( "cartoon", { opacity: 0.5, side: THREE.FrontSide, assembly: "UNITCELL" } );
+			
+			// operators to create the unit cell
+			var operators = [
+			{{#graph.unitCellTransforms}} 
+			new THREE.Matrix4().set(
+				{{m00}}, {{m01}}, {{m02}}, {{m03}},
+				{{m10}}, {{m11}}, {{m12}}, {{m13}},
+				{{m20}}, {{m21}}, {{m22}}, {{m23}},
+				{{m30}}, {{m31}}, {{m32}}, {{m33}}),
+			{{/graph.unitCellTransforms}}
+			];
+			
+			// show full unit cell with NGL's built-in assembly
+			//o.addRepresentation( "cartoon", { opacity: 0.5, side: THREE.FrontSide, assembly: "UNITCELL" } );
+			
+			// show our own full unit cell from our operators list		
+			var assembly = new NGL.Assembly( "LATTICEGRAPH_UNITCELL" );
+			for (var i=0; i < operators.length; i++) {
+				assembly.addPart(
+					[ operators[i] ],
+					[]  // leave empty for all chains, otherwise author chainnames [ "A", "B" ]
+				);
+			}
+			o.structure.biomolDict[ "LATTICEGRAPH_UNITCELL" ] = assembly;
+			o.addRepresentation( "cartoon", { opacity: 0.5, side: THREE.FrontSide, assembly: "LATTICEGRAPH_UNITCELL" } );
+			
 			
 			////////  spheres  ///////////////////////////////////////////////
 			var spherePositions = [

--- a/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/generators/AssemblyDiagramPageGenerator.java
+++ b/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/generators/AssemblyDiagramPageGenerator.java
@@ -19,6 +19,7 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 
+import ch.systemsx.sybit.crkwebui.server.jmol.servlets.LatticeGraphServlet;
 import ch.systemsx.sybit.crkwebui.shared.model.Interface;
 import eppic.assembly.ChainVertex3D;
 import eppic.assembly.InterfaceEdge3D;
@@ -56,7 +57,8 @@ public class AssemblyDiagramPageGenerator {
 			List<Interface> interfaces,
 			Collection<Integer> requestedIfaces, PrintWriter out) throws IOException, StructureException {
 
-		Structure auStruct = LatticeGraphPageGenerator.readStructure(directory, inputName, atomCachePath);
+		File auFile = LatticeGraphServlet.getAuFileName(directory, inputName, atomCachePath);
+		Structure auStruct = LatticeGraphPageGenerator.readStructure(auFile);
 		
 		// Read spacegroup
 		PDBCrystallographicInfo crystInfo = auStruct

--- a/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/generators/LatticeGraphPageGenerator.java
+++ b/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/generators/LatticeGraphPageGenerator.java
@@ -88,9 +88,9 @@ public class LatticeGraphPageGenerator {
 
 		// Write unit cell, if necessary
 		if( !ucFile.exists() ) {
-			logger.info("Writing Unit Cell file to {}",ucFile.getAbsolutePath());
+			logger.info("Mmcif file of AU could not be found in {}, writing file to {}",ucFile.toString(), ucFile.toString());
 			PrintWriter cifOut = new PrintWriter(new GZIPOutputStream(new FileOutputStream(ucFile)));
-			gui.writeCIFfile(cifOut);
+			cifOut.println(auStruct.toMMCIF());
 			cifOut.close();
 		}
 

--- a/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
+++ b/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
@@ -32,7 +32,6 @@ import ch.systemsx.sybit.crkwebui.shared.exceptions.DaoException;
 import ch.systemsx.sybit.crkwebui.shared.exceptions.ValidationException;
 import ch.systemsx.sybit.crkwebui.shared.model.Interface;
 import ch.systemsx.sybit.crkwebui.shared.model.PdbInfo;
-import eppic.EppicParams;
 import eppic.commons.util.Interval;
 import eppic.commons.util.IntervalSet;
 import eppic.model.JobDB;
@@ -114,8 +113,8 @@ public class LatticeGraphServlet extends BaseServlet
 			File dir = DirLocatorUtil.getJobDir(new File(destination_path), jobId);
 
 			// Construct UC filename
-			File ucFile = new File(dir,inputPrefix + EppicParams.UNIT_CELL_COORD_FILES_SUFFIX + ".cif.gz");
-			String ucURI = DirLocatorUtil.getJobUrlPath(resultsLocation, jobId) + "/" + inputPrefix + EppicParams.UNIT_CELL_COORD_FILES_SUFFIX + ".cif";
+			File ucFile = new File(dir, inputPrefix + ".cif.gz");
+			String ucURI = DirLocatorUtil.getJobUrlPath(resultsLocation, jobId) + "/" + inputPrefix + ".cif";
 
 			List<Interface> ifaceList = getInterfaceList(pdbInfo);
 

--- a/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
+++ b/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
@@ -112,9 +112,9 @@ public class LatticeGraphServlet extends BaseServlet
 			// job directory on local filesystem
 			File dir = DirLocatorUtil.getJobDir(new File(destination_path), jobId);
 
-			// Construct UC filename
-			File ucFile = new File(dir, inputPrefix + ".cif.gz");
-			String ucURI = DirLocatorUtil.getJobUrlPath(resultsLocation, jobId) + "/" + inputPrefix + ".cif";
+			// Construct filename for AU cif file
+			File auFile = new File(dir, inputPrefix + ".cif.gz");
+			String auURI = DirLocatorUtil.getJobUrlPath(resultsLocation, jobId) + "/" + inputPrefix + ".cif";
 
 			List<Interface> ifaceList = getInterfaceList(pdbInfo);
 
@@ -138,7 +138,7 @@ public class LatticeGraphServlet extends BaseServlet
 			}
 			
 
-			LatticeGraphPageGenerator.generatePage(dir,input, atomCachePath, ucFile, ucURI, title, size, ifaceList, requestedIfaces, outputStream, nglJsUrl);
+			LatticeGraphPageGenerator.generatePage(dir,input, atomCachePath, auFile, auURI, title, size, ifaceList, requestedIfaces, outputStream, nglJsUrl);
 
 		}
 		catch(ValidationException e)

--- a/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
+++ b/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
@@ -118,11 +118,11 @@ public class LatticeGraphServlet extends BaseServlet
 			// Construct filename for AU cif file
 			File auFile = getAuFileName(dir, input, atomCachePath);
 			
-			String inputFileNameNoGz = input;
-			if (input.endsWith(".gz")) {
-				inputFileNameNoGz = input.substring(0, input.lastIndexOf(".gz"));
-			} else if (input.endsWith(".GZ")) {
-				inputFileNameNoGz = input.substring(0, input.lastIndexOf(".GZ"));
+			String inputFileNameNoGz = auFile.getName();
+			if (auFile.getName().endsWith(".gz")) {
+				inputFileNameNoGz = auFile.getName().substring(0, auFile.getName().lastIndexOf(".gz"));
+			} else if (auFile.getName().endsWith(".GZ")) {
+				inputFileNameNoGz = auFile.getName().substring(0, auFile.getName().lastIndexOf(".GZ"));
 					
 			}
 			// the URL has no gz at the end because it's served as plain text via content-encoding: gzip
@@ -300,12 +300,13 @@ public class LatticeGraphServlet extends BaseServlet
 					logger.error("The structure file {} does not exist in atom cache! Will not be able to display lattice graph", structFile.toString());
 					throw new IOException("Structure file " + structFile.toString()+" does not exist in atom cache");
 				}
-				
+
 				File sLink = new File(directory, structFile.getName());
-				// we create a symbolic link to the file in the atomcache dir
-				logger.info("Creating symbolic link {} to file {}", sLink.toString(), structFile.toString());
-				Files.createSymbolicLink(sLink.toPath(), structFile.toPath());
-				
+				if (!sLink.exists()) {
+					// we create a symbolic link to the file in the atomcache dir
+					logger.info("Creating symbolic link {} to file {}", sLink.toString(), structFile.toString());
+					Files.createSymbolicLink(sLink.toPath(), structFile.toPath());
+				}
 				// and finally if no exception is thrown we return the symbolic link
 				structFile = sLink;
 			}

--- a/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
+++ b/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
@@ -303,9 +303,16 @@ public class LatticeGraphServlet extends BaseServlet
 
 				File sLink = new File(directory, structFile.getName());
 				if (!sLink.exists()) {
+					
+					// TODO downloading symlinks don't work with current server configuration, 
+					// TODO for now resorting to copy: must fix server config and do it with symlinks!
+					
+					logger.info("Copying to {} from file {}", sLink.toString(), structFile.toString());
+					Files.copy(structFile.toPath(), sLink.toPath() );
+					
 					// we create a symbolic link to the file in the atomcache dir
-					logger.info("Creating symbolic link {} to file {}", sLink.toString(), structFile.toString());
-					Files.createSymbolicLink(sLink.toPath(), structFile.toPath());
+					//logger.info("Creating symbolic link {} to file {}", sLink.toString(), structFile.toString());
+					//Files.createSymbolicLink(sLink.toPath(), structFile.toPath());
 				}
 				// and finally if no exception is thrown we return the symbolic link
 				structFile = sLink;

--- a/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
+++ b/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/server/jmol/servlets/LatticeGraphServlet.java
@@ -3,6 +3,7 @@ package ch.systemsx.sybit.crkwebui.server.jmol.servlets;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.List;
 import java.util.SortedSet;
@@ -14,6 +15,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.align.util.AtomCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +34,7 @@ import ch.systemsx.sybit.crkwebui.shared.exceptions.DaoException;
 import ch.systemsx.sybit.crkwebui.shared.exceptions.ValidationException;
 import ch.systemsx.sybit.crkwebui.shared.model.Interface;
 import ch.systemsx.sybit.crkwebui.shared.model.PdbInfo;
+import eppic.assembly.gui.LatticeGUI;
 import eppic.commons.util.Interval;
 import eppic.commons.util.IntervalSet;
 import eppic.model.JobDB;
@@ -107,14 +110,23 @@ public class LatticeGraphServlet extends BaseServlet
 
 			PdbInfo pdbInfo = getPdbInfo(jobId);
 			String input = pdbInfo.getInputName();
-			String inputPrefix = pdbInfo.getTruncatedInputName();
+			//String inputPrefix = pdbInfo.getTruncatedInputName();
 
 			// job directory on local filesystem
 			File dir = DirLocatorUtil.getJobDir(new File(destination_path), jobId);
 
 			// Construct filename for AU cif file
-			File auFile = new File(dir, inputPrefix + ".cif.gz");
-			String auURI = DirLocatorUtil.getJobUrlPath(resultsLocation, jobId) + "/" + inputPrefix + ".cif";
+			File auFile = getAuFileName(dir, input, atomCachePath);
+			
+			String inputFileNameNoGz = input;
+			if (input.endsWith(".gz")) {
+				inputFileNameNoGz = input.substring(0, input.lastIndexOf(".gz"));
+			} else if (input.endsWith(".GZ")) {
+				inputFileNameNoGz = input.substring(0, input.lastIndexOf(".GZ"));
+					
+			}
+			// the URL has no gz at the end because it's served as plain text via content-encoding: gzip
+			String auURI = DirLocatorUtil.getJobUrlPath(resultsLocation, jobId) + "/" + inputFileNameNoGz;
 
 			List<Interface> ifaceList = getInterfaceList(pdbInfo);
 
@@ -138,7 +150,7 @@ public class LatticeGraphServlet extends BaseServlet
 			}
 			
 
-			LatticeGraphPageGenerator.generatePage(dir,input, atomCachePath, auFile, auURI, title, size, ifaceList, requestedIfaces, outputStream, nglJsUrl);
+			LatticeGraphPageGenerator.generatePage(dir,input, auFile, auURI, title, size, ifaceList, requestedIfaces, outputStream, nglJsUrl);
 
 		}
 		catch(ValidationException e)
@@ -243,5 +255,62 @@ public class LatticeGraphServlet extends BaseServlet
 			}
 		}
 		return new IntervalSet(interfaces);
+	}
+	
+	/**
+	 * Returns the file name of the input structure: if user job it returns 
+	 * the path to the file in the job dir, if precomputed it finds the file path
+	 * in the local atom cache and creates a symbolic link to it in the job dir
+	 * @param directory Directory to search for the file
+	 * @param inputName either the input file name, or a PDB code
+	 * @param atomCachePath Path for downloaded CIF files
+	 * @return the path to the AU structure file in the job dir
+	 * @throws IOException if file is a user job file and can't be found, 
+	 * or if the input is a pdb id and its file can't be found in atom cache
+	 */
+	public static File getAuFileName(File directory, String inputName, String atomCachePath) throws IOException {
+		
+		// inputName will be the full file name in user jobs and the pdbId for precomputed jobs
+		File structFile = new File(directory,inputName);
+		logger.info("Trying to find the structure file for input name '{}'. Searching file in {}", inputName, structFile.toString());
+
+		if(!structFile.exists()){
+			if  (!inputName.matches("^\\d\\w\\w\\w$")) {
+				throw new IOException(String.format(
+						"Could not find file %s and the inputName '%s' does not look "
+								+ "like a PDB id. Can't produce the lattice graph page!",
+								structFile, inputName));
+			} else {
+				
+				// it is like a PDB id, leave it to AtomCache
+				AtomCache atomCache = null;
+				if (atomCachePath ==null) {
+					atomCache = new AtomCache();
+					logger.warn("Defaulting to downloading structures to {}. Please set the ATOM_CACHE_PATH property.",atomCache.getCachePath());
+				}
+				else {
+					atomCache = new AtomCache(atomCachePath);
+				}
+
+				atomCache.setUseMmCif(true);
+
+				structFile = LatticeGUI.getFile(atomCache, inputName);
+				
+				if (!structFile.exists()) {
+					logger.error("The structure file {} does not exist in atom cache! Will not be able to display lattice graph", structFile.toString());
+					throw new IOException("Structure file " + structFile.toString()+" does not exist in atom cache");
+				}
+				
+				File sLink = new File(directory, structFile.getName());
+				// we create a symbolic link to the file in the atomcache dir
+				logger.info("Creating symbolic link {} to file {}", sLink.toString(), structFile.toString());
+				Files.createSymbolicLink(sLink.toPath(), structFile.toPath());
+				
+				// and finally if no exception is thrown we return the symbolic link
+				structFile = sLink;
+			}
+		}
+		
+		return structFile;
 	}
 }


### PR DESCRIPTION
This covers the last point in issue #94 (replace cell.cif with custom assembly) as well as making #130 irrelevant as there's no need anymore for a unit cell file. 

Together with that, a few fixes that make the lattice graph work properly for user jobs. The whole process is now much more efficient server-side: AU file is read only once and no file writing is needed: only symlinking it from atom cache dir. For the moment symlinks didn't work with current server config so I had to resort back to copying the file from the atom cache dir.