### PR TITLE
Probabilistic score for interfaces

### DIFF
--- a/eppic-cli/src/main/java/eppic/EppicParams.java
+++ b/eppic-cli/src/main/java/eppic/EppicParams.java
@@ -206,6 +206,13 @@ public class EppicParams {
 	
 	// default use pdb res serials for output
 	public static final boolean   DEF_USE_PDB_RES_SER = true;
+	
+	// Logistic regression model parameters (coefficients)
+	public static final double LOGIT_INTERSECT = -3.9;
+	public static final double LOGIT_GM_COEFFICIENT = 0.3;
+	public static final double LOGIT_CR_COEFFICIENT = 0.0;
+	public static final double LOGIT_CS_COEFFICIENT = -2.0;
+	public static final double LOGIT_AREA_COEFFICIENT = 0.0;
 		
 
 	// FIELDS

--- a/eppic-cli/src/main/java/eppic/EppicParams.java
+++ b/eppic-cli/src/main/java/eppic/EppicParams.java
@@ -213,6 +213,10 @@ public class EppicParams {
 	public static final double LOGIT_CR_COEFFICIENT = 0.0;
 	public static final double LOGIT_CS_COEFFICIENT = -2.0;
 	public static final double LOGIT_AREA_COEFFICIENT = 0.0;
+	
+	// Confidence thresholds for the WUI stars
+	public static final double HIGH_CONFIDENCE = 0.9;
+	public static final double MEDIUM_CONFIDENCE = 0.75;
 		
 
 	// FIELDS

--- a/eppic-cli/src/main/java/eppic/EppicParams.java
+++ b/eppic-cli/src/main/java/eppic/EppicParams.java
@@ -207,16 +207,36 @@ public class EppicParams {
 	// default use pdb res serials for output
 	public static final boolean   DEF_USE_PDB_RES_SER = true;
 	
-	// Logistic regression model parameters (coefficients)
+	// Logistic regression model for interface classification
+	/** Intersection of the logistic regression classifier */
 	public static final double LOGIT_INTERSECT = -3.9;
-	public static final double LOGIT_GM_COEFFICIENT = 0.3;
-	public static final double LOGIT_CR_COEFFICIENT = 0.0;
-	public static final double LOGIT_CS_COEFFICIENT = -2.0;
-	public static final double LOGIT_AREA_COEFFICIENT = 0.0;
 	
-	// Confidence thresholds for the WUI stars
-	public static final double HIGH_CONFIDENCE = 0.9;
-	public static final double MEDIUM_CONFIDENCE = 0.75;
+	/** Geometry score coefficient of the logistic regression classifier */
+	public static final double LOGIT_GM_COEFFICIENT = 0.31;
+	
+	/** Core-Surface score coefficient of the logistic regression classifier */
+	public static final double LOGIT_CS_COEFFICIENT = -2.1;
+	
+	/** Number of features included in the logistic regression classifier */
+	public static final int LOGIT_NUM_FEATURES = 2;
+	
+	/**
+	 * Most uncertain Core-Surface score value for the logistic regression 
+	 * classifier, for interfaces with not enough number of homologous 
+	 * sequences (NOPRED).
+	 * <p>
+	 * This value is calculated so that the Geometry score decides alone the
+	 * final call, but with higher uncertainty due to the lack of sequences.
+	 **/
+	public static final double LOGIT_CS_NOPRED = - LOGIT_INTERSECT / 
+			(LOGIT_NUM_FEATURES * LOGIT_CS_COEFFICIENT);
+	
+	// Probability thresholds for the WUI call confidence stars
+	/** Calls with probabilities higher than this value are considered high confidence */
+	public static final double HIGH_PROB_CONFIDENCE = 0.95;
+	
+	/** Calls with probabilities lower than this value are considered low confidence */
+	public static final double LOW_PROB_CONFIDENCE = 0.8;
 		
 
 	// FIELDS

--- a/eppic-cli/src/main/java/eppic/Main.java
+++ b/eppic-cli/src/main/java/eppic/Main.java
@@ -835,8 +835,8 @@ public class Main {
 	public void doCombinedScoring() throws EppicException {
 		if (interfaces.size()==0) return;
 		
+		// interface scoring
 		List<CombinedPredictor> cps = new ArrayList<CombinedPredictor>();
-
 		for (int i=0;i<iecList.size();i++) {
 			CombinedPredictor cp = 
 					new CombinedPredictor(iecList.get(i), gps.get(i), iecList.get(i).getEvolCoreRimPredictor(), iecList.get(i).getEvolCoreSurfacePredictor());
@@ -844,23 +844,23 @@ public class Main {
 			cps.add(cp);
 		}
 		
+		// interface cluster scoring
 		List<CombinedClusterPredictor> ccps = new ArrayList<CombinedClusterPredictor>();		
-		int i = 0;
-		for (StructureInterfaceCluster ic:interfaces.getClusters(EppicParams.CLUSTERING_CONTACT_OVERLAP_SCORE_CUTOFF)) {
-			int clusterId = ic.getId();
-			CombinedClusterPredictor ccp = 
-					new CombinedClusterPredictor(ic,iecList,
-							gcps.get(i),
-							iecList.getEvolCoreRimClusterPredictor(clusterId),
-							iecList.getEvolCoreSurfaceClusterPredictor(clusterId));
+		for (StructureInterfaceCluster interfaceCluster:interfaces.getClusters(EppicParams.CLUSTERING_CONTACT_OVERLAP_SCORE_CUTOFF)) {
+			List<CombinedPredictor> ccpsForCluster = new ArrayList<CombinedPredictor>();
 			
+			for (int i=0;i<interfaces.size();i++) {
+				if ( interfaces.get(i+1).getCluster().getId()==interfaceCluster.getId()) {
+					ccpsForCluster.add(cps.get(i));
+				}
+			}
+			
+			CombinedClusterPredictor ccp = new CombinedClusterPredictor(ccpsForCluster);
+
 			ccp.computeScores();
 			ccps.add(ccp);
-			i++;
-			
-			iecList.setCombinedClusterPredictor(clusterId, ccp);
-		}
-				
+			iecList.setCombinedClusterPredictor(interfaceCluster.getId(), ccp);
+		}			
 
 		modelAdaptor.setCombinedPredictors(cps, ccps);
 

--- a/eppic-cli/src/main/java/eppic/TextOutputWriter.java
+++ b/eppic-cli/src/main/java/eppic/TextOutputWriter.java
@@ -218,7 +218,7 @@ public class TextOutputWriter {
 		if (interfaceScoreFn==null) {
 			ps.printf("\t%7s\t%7s\t%7s","","","");
 		} else {
-			ps.printf("\t%7.0f\t%7.2f\t%7s",
+			ps.printf("\t%7.2f\t%7.2f\t%7s",
 					interfaceScoreFn.getScore(),
 					interfaceScoreFn.getConfidence(),
 					interfaceScoreFn.getCallName());			
@@ -283,7 +283,7 @@ public class TextOutputWriter {
 		if (interfaceScoreFn==null) {
 			ps.printf("\t%7s\t%7s\t%7s","","","");
 		} else {
-			ps.printf("\t%7.0f\t%7.2f\t%7s",
+			ps.printf("\t%7.2f\t%7.2f\t%7s",
 					interfaceScoreFn.getScore(),
 					interfaceScoreFn.getConfidence(),
 					interfaceScoreFn.getCallName());			

--- a/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
+++ b/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
@@ -2,101 +2,49 @@ package eppic.predictors;
 
 import java.util.List;
 
-import org.biojava.nbio.structure.contact.StructureInterface;
-import org.biojava.nbio.structure.contact.StructureInterfaceCluster;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import eppic.CallType;
-import eppic.InterfaceEvolContext;
-import eppic.InterfaceEvolContextList;
 
 public class CombinedClusterPredictor implements InterfaceTypePredictor {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CombinedClusterPredictor.class);
-	
-	private InterfaceEvolContextList iecl;
-	
-	private StructureInterfaceCluster ic;
-	private InterfaceTypePredictor gcp;
-	private InterfaceTypePredictor ecrcp;
-	private InterfaceTypePredictor ecscp;
+	private List<CombinedPredictor> list;
 	
 	private CallType call;
 	private String callReason;
 	
-	private int votes;
-	
+	private double probability;
 	private double confidence;
 	
 	
-	public CombinedClusterPredictor(StructureInterfaceCluster interfaceCluster,
-			InterfaceEvolContextList iecl,
-			GeometryClusterPredictor gcp,
-			EvolCoreRimClusterPredictor ecrcp,
-			EvolCoreSurfaceClusterPredictor ecscp) {
-		
-		this.iecl = iecl;
-		this.ic = interfaceCluster;
-		this.gcp = gcp;
-		this.ecrcp = ecrcp;
-		this.ecscp = ecscp;
+	public CombinedClusterPredictor(List<CombinedPredictor> lcp) {
+		this.list = lcp;
+	}
+	
+	private void calcProbability() {
+		// Take the average of the probabilities
+		probability = 0;
+		for (CombinedPredictor cp : list) {
+			probability += cp.getScore();
+		}
+		probability = probability / (double) list.size();
 	}
 
 	@Override
 	public void computeScores() {
 		
-		checkInterface();
+		calcProbability();
+		
+		// 1) BIO call
+		if (probability > 0.5) {
+			callReason = "P(BIO) = " + probability + " > 0.5";
+			call = CallType.BIO;
+		} 
+		// 2) XTAL call
+		else if (probability < 0.5) {
+			callReason = "P(BIO) = " + probability + " < 0.5";
+			call = CallType.CRYSTAL;
+		}
 		
 		calcConfidence();
-		
-		boolean isNonProt = false;
-		for (StructureInterface interf:ic.getMembers()) {
-			if (!InterfaceEvolContext.isProtein(interf, InterfaceEvolContext.FIRST) &&
-				!InterfaceEvolContext.isProtein(interf, InterfaceEvolContext.SECOND)) {
-				isNonProt = true;
-			}
-			// break after one iteration: all interfaces in the cluster should be either prot or non-prot 
-			break;
-		}
-		if (isNonProt) {
-			LOGGER.info("Interface cluster {} is not protein in either side, can't score it",ic.getId());
-			callReason = "Both sides are not protein, can't score";
-			call = CallType.NO_PREDICTION;
-			votes = -1;
-			return;
-		}
-
-		// STRATEGY 1: consensus, when no evolution take geometry, when no consensus take evol
-		int[] counts = countCalls();
-		// 1) 2 bio calls
-		if (counts[0]>=2) {
-			callReason = "BIO consensus ("+counts[0]+" votes)";
-			call = CallType.BIO;
-			votes = counts[0];
-		} 
-		// 2) 2 xtal calls
-		else if (counts[1]>=2) {
-			callReason = "XTAL consensus ("+counts[1]+" votes)";
-			call = CallType.CRYSTAL;
-			votes = counts[1];
-		}
-		// 3) 2 nopreds (necessarily from the evol methods): we take geometry as the call
-		else if (counts[2]==2) {
-			callReason = "Prediction purely geometrical (no evolutionary prediction could be made)";
-			call = gcp.getCall();
-			votes = 1;
-		}
-		// 4) 1 nopred (an evol method), 1 xtal, 1 bio
-		else {
-			// take evol call
-			if (ecrcp.getCall()!=CallType.NO_PREDICTION) call = ecrcp.getCall();
-			else if (ecscp.getCall()!=CallType.NO_PREDICTION) call = ecscp.getCall();
-			else System.err.println("Warning! both core-surface and core-rim called nopred. Something went wrong in vote counts");
-
-			callReason = "No consensus. Taking evolutionary call as final";
-			votes = 1;
-		}
 
 	}
 
@@ -117,7 +65,7 @@ public class CombinedClusterPredictor implements InterfaceTypePredictor {
 
 	@Override
 	public double getScore() {		
-		return (double)votes;
+		return probability;
 	}
 
 	@Override
@@ -135,52 +83,20 @@ public class CombinedClusterPredictor implements InterfaceTypePredictor {
 		return confidence;
 	}
 	
-	private boolean checkInterface() {
-
-		// we used to do hard area limits here, but thats' gone now		
-		
-		return true; // for the moment there's no conditions to reject a score
-	}
-	
-	private int[] countCalls() {
-		int[] counts = new int[3]; // biocalls, xtalcalls, nopredcalls
-		if (gcp.getCall()==CallType.BIO) counts[0]++;
-		else if (gcp.getCall()==CallType.CRYSTAL) counts[1]++;
-		else if (gcp.getCall()==CallType.NO_PREDICTION) counts[2]++; // this can't happen in principle, there's always a geom prediction
-
-		if (ecrcp.getCall()==CallType.BIO) counts[0]++;
-		else if (ecrcp.getCall()==CallType.CRYSTAL) counts[1]++;
-		else if (ecrcp.getCall()==CallType.NO_PREDICTION) counts[2]++;
-
-		if (ecscp.getCall()==CallType.BIO) counts[0]++;
-		else if (ecscp.getCall()==CallType.CRYSTAL) counts[1]++;
-		else if (ecscp.getCall()==CallType.NO_PREDICTION) counts[2]++;
-
-		return counts;
-	}
-	
 	private void calcConfidence() {
 		
-		// TODO possible idea: if within hard area limits, give high confidence to the call
+		switch (call) {
+		case BIO: 
+			confidence = (probability - 0.5) / 0.5;
+			break;
+		case CRYSTAL: 
+			confidence = (0.5 - probability) / 0.5;
+			break;
+		case NO_PREDICTION: 
+			confidence = CONFIDENCE_UNASSIGNED;
 		
-		// we simply take the first member of the cluster and check if there enough homologs for it, other members should have same composition
-		
-		String firstPdbChainCode = ic.getMembers().get(0).getMoleculeIds().getFirst();
-		String secondPdbChainCode = ic.getMembers().get(0).getMoleculeIds().getSecond();
-		
-		int firstNumHomologs = iecl.getChainEvolContext(firstPdbChainCode).getNumHomologs();
-		int secondNumHomologs = iecl.getChainEvolContext(secondPdbChainCode).getNumHomologs();
-		
-		
-		if ( firstNumHomologs<iecl.getMinNumSeqs() && secondNumHomologs<iecl.getMinNumSeqs()) {
-			confidence = CONFIDENCE_LOW;
-		} else if (firstNumHomologs<iecl.getMinNumSeqs()) {
-			confidence = CONFIDENCE_MEDIUM;
-		} else if (secondNumHomologs<iecl.getMinNumSeqs()) {
-			confidence = CONFIDENCE_MEDIUM;
-		} else {
-			confidence = CONFIDENCE_HIGH;
 		}
+		
 	}
 
 }

--- a/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
+++ b/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
@@ -39,7 +39,7 @@ public class CombinedClusterPredictor implements InterfaceTypePredictor {
 			call = CallType.BIO;
 		} 
 		// 2) XTAL call
-		else if (probability < 0.5) {
+		else if (probability <= 0.5) {
 			callReason = "P(BIO) = " + probability + " < 0.5";
 			call = CallType.CRYSTAL;
 		}

--- a/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
+++ b/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
@@ -87,10 +87,10 @@ public class CombinedClusterPredictor implements InterfaceTypePredictor {
 		
 		switch (call) {
 		case BIO: 
-			confidence = (probability - 0.5) / 0.5;
+			confidence = probability;
 			break;
 		case CRYSTAL: 
-			confidence = (0.5 - probability) / 0.5;
+			confidence = 1 - probability;
 			break;
 		case NO_PREDICTION: 
 			confidence = CONFIDENCE_UNASSIGNED;

--- a/eppic-cli/src/main/java/eppic/predictors/CombinedPredictor.java
+++ b/eppic-cli/src/main/java/eppic/predictors/CombinedPredictor.java
@@ -117,7 +117,7 @@ public class CombinedPredictor implements InterfaceTypePredictor {
 			call = CallType.BIO;
 		} 
 		// 2) XTAL call
-		else if (probability < 0.5) {
+		else if (probability <= 0.5) {
 			callReason = "P(BIO) = " + probability + " < 0.5";
 			call = CallType.CRYSTAL;
 		}

--- a/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/client/results/gui/cells/MethodCallCell.java
+++ b/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/client/results/gui/cells/MethodCallCell.java
@@ -15,6 +15,7 @@ import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.sencha.gxt.data.shared.ListStore;
 
+import eppic.EppicParams;
 import eppic.model.ScoringMethod;
 
 /**
@@ -76,8 +77,7 @@ public class MethodCallCell extends AbstractCell<String> {
 
 		if(type.equals(ScoringMethod.EPPIC_FINAL)) {
 		    value = value.toUpperCase();
-		    // disabling this for 2.1.0 release, put back when confidence calculation implementation is better - JD 07.07.2014
-		    //value += addIcon(item.getConfidence());
+		    value += addIcon(item.getConfidence());
 		}
 
 		tooltipText = EscapedStringGenerator.generateEscapedString(tooltipText);
@@ -85,11 +85,10 @@ public class MethodCallCell extends AbstractCell<String> {
 		sb.appendHtmlConstant("<span style='color:" + color + ";' qtip='" + tooltipText + "'>"+ value +"</span>");
 	}
 
-	@SuppressWarnings("unused")
 	private String addIcon(double d) {
-	    if(d > .66)
+	    if(d > EppicParams.HIGH_CONFIDENCE)
 		return "<img src=\"resources/icons/excellent.png\" width=\"16\">";
-	    if(d > .33)
+	    if(d > EppicParams.MEDIUM_CONFIDENCE)
 		return "</img><img src=\"resources/icons/good.png\" width=\"16\"></img>";
 	    return "";
 	}

--- a/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/client/results/gui/cells/MethodCallCell.java
+++ b/eppic-wui/src/main/java/ch/systemsx/sybit/crkwebui/client/results/gui/cells/MethodCallCell.java
@@ -86,9 +86,9 @@ public class MethodCallCell extends AbstractCell<String> {
 	}
 
 	private String addIcon(double d) {
-	    if(d > EppicParams.HIGH_CONFIDENCE)
+	    if(d > EppicParams.HIGH_PROB_CONFIDENCE)
 		return "<img src=\"resources/icons/excellent.png\" width=\"16\">";
-	    if(d > EppicParams.MEDIUM_CONFIDENCE)
+	    if(d > EppicParams.LOW_PROB_CONFIDENCE)
 		return "</img><img src=\"resources/icons/good.png\" width=\"16\"></img>";
 	    return "";
 	}


### PR DESCRIPTION
This addresses the EPPIC interface call confidence #14 by combining the EPPIC scores with a logistic regression classifier. The `CombinedPredictor` does not use votes anymore, but the logistic function.