### PR TITLE
Fixing json file naming convention

### DIFF
--- a/eppic-cli/src/main/java/eppic/EppicParams.java
+++ b/eppic-cli/src/main/java/eppic/EppicParams.java
@@ -680,15 +680,19 @@ public class EppicParams {
 	}
 	
 	/**
-	 * Gets the suffix of the json file for the wui js assembly diagram in the form <pre>{@value #ASSEMBLIES_DIAGRAM_FILES_SUFFIX}.&lt;interface interval&gt;.json</pre>
-	 * @param interfaceIds
+	 * Gets the suffix of the json file for the wui js assembly diagram in the 
+	 * form <pre>{@value #ASSEMBLIES_DIAGRAM_FILES_SUFFIX}.&lt;interface interval&gt;.json</pre>
+	 * @param interfaceIds an empty collection will result in an "empty" interface interval suffix, 
+	 * whilst a null collection will result in a "*" interface interval suffix
 	 * @return
 	 */
 	public static String get2dDiagramJsonFilenameSuffix(Collection<Integer> interfaceIds) {
 		String interfaceIntervals;
-		if(interfaceIds == null || interfaceIds.isEmpty() ) {
+		if (interfaceIds == null) {
 			interfaceIntervals = "*";
-		} else {
+		} else if (interfaceIds.isEmpty() ) {
+			interfaceIntervals = "empty";
+		}else {
 			interfaceIntervals = new IntervalSet(new TreeSet<>(interfaceIds)).toSelectionString();
 		}
 		
@@ -696,14 +700,18 @@ public class EppicParams {
 	}
 	
 	/**
-	 * Gets the suffix of the json file for the wui 3d lattice graph assembly diagram in the form <pre>{@value #ASSEMBLIES_3DGRAPH_FILES_SUFFIX}.&lt;interface interval&gt;.json</pre>
-	 * @param interfaceIds
+	 * Gets the suffix of the json file for the wui 3d lattice graph assembly diagram in the
+	 * form <pre>{@value #ASSEMBLIES_3DGRAPH_FILES_SUFFIX}.&lt;interface interval&gt;.json</pre>
+	 * @param interfaceIds an empty collection will result in an "empty" interface interval suffix, 
+	 * whilst a null collection will result in a "*" interface interval suffix
 	 * @return
 	 */
 	public static String get3dLatticeGraphJsonFilenameSuffix(Collection<Integer> interfaceIds) {
 		String interfaceIntervals;
-		if(interfaceIds == null || interfaceIds.isEmpty() ) {
+		if (interfaceIds == null) {
 			interfaceIntervals = "*";
+		} else if (interfaceIds.isEmpty() ) {
+			interfaceIntervals = "empty";
 		} else {
 			interfaceIntervals = new IntervalSet(new TreeSet<>(interfaceIds)).toSelectionString();
 		}

--- a/eppic-cli/src/main/java/eppic/Main.java
+++ b/eppic-cli/src/main/java/eppic/Main.java
@@ -643,7 +643,21 @@ public class Main {
 				
 				
 			}
+			
+			// additionally for the lattice graph 3d we need the full graph "*" file, i.e. all interfaces engaged
+			// used in "view unit cell"
+			
+			latticeGraph.filterEngagedClusters(null);
+			latticeGraph.setHexColors();
 
+			String json = gson.toJson(latticeGraph);
+
+			File jsonLatticeGraphFile = params.getOutputFile(EppicParams.get3dLatticeGraphJsonFilenameSuffix(null));
+
+			PrintWriter pw = new PrintWriter(new FileWriter(jsonLatticeGraphFile));
+			pw.println(json);
+			pw.close();
+			
 		} catch( IOException|StructureException|InterruptedException e) {
 			throw new EppicException(e, "Couldn't write assembly diagrams. " + e.getMessage(), true);
 		}


### PR DESCRIPTION
At the moment json file names with suffix "\*" were representing both the empty interval and the infinite interval. With this fix there are now 2 suffixes "\*" for the infinite interval and "empty" for the empty interval. This fixes the full 3d lattice graph view.