### PR TITLE
Assembly scoring: fix #158 and solve ties in assembly scoring #161

### DIFF
--- a/eppic-cli/src/main/java/eppic/assembly/CrystalAssemblies.java
+++ b/eppic-cli/src/main/java/eppic/assembly/CrystalAssemblies.java
@@ -587,19 +587,36 @@ public class CrystalAssemblies implements Iterable<Assembly> {
 			indx++;
 		}
 		
+		// This is done when multiple assemblies are high scoring
+		indx = 0;
+		List<Integer> indices = new ArrayList<Integer>();
+		for (Assembly a:uniques) {
+			if (a.getScore() == maxScore){
+				indices.add(indx);
+			}
+			indx++;
+		}
+		
 		// Warn if low probability density of valid assemblies
 		if (sumProbs < 0.5) {
 			logger.warn("The total probability of valid assemblies is only {}. "
 					+ "Assembly ennumeration may be incomplete.", String.format("%.2f", sumProbs));
 		}
 		
-		// Do not normalize the score (easy to do afterwards though)
+		// Do not normalize the score (easy to do afterwards in the DB though)
 		//for (Assembly a:uniques)
 		//	a.normalizeScore(sumProbs);
 		
-		// 3 Assign the BIO call to the highest probability
-		if (uniques.size() > 0)
-			uniques.get(maxIndx).setCall(CallType.BIO);
+		// 3 Assign the BIO call to the highest probability, if unique assembly
+		if (uniques.size() > 0) {
+			if (indices.size() == 1) {
+				uniques.get(maxIndx).setCall(CallType.BIO);
+			} else {
+				for (Integer i:indices) {
+					uniques.get(i).setCall(CallType.NO_PREDICTION);
+				}
+			}
+		}
 		
 		// 4 Compute call confidence
 		for (Assembly a:uniques)

--- a/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
+++ b/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
@@ -35,12 +35,16 @@ public class CombinedClusterPredictor implements InterfaceTypePredictor {
 		
 		// 1) BIO call
 		if (probability > 0.5) {
-			callReason = String.format("P(BIO) = %.2f > 0.5", probability);
+			callReason = String.format(
+					"Probability of the interface being biologically relevant is %.2f.",
+					probability);
 			call = CallType.BIO;
-		} 
+		}
 		// 2) XTAL call
 		else if (probability <= 0.5) {
-			callReason = String.format("P(BIO) = %.2f < 0.5", probability);
+			callReason = String.format(
+					"Probability of the interface being biologically relevant is %.2f.",
+					probability);
 			call = CallType.CRYSTAL;
 		}
 		

--- a/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
+++ b/eppic-cli/src/main/java/eppic/predictors/CombinedClusterPredictor.java
@@ -11,8 +11,8 @@ public class CombinedClusterPredictor implements InterfaceTypePredictor {
 	private CallType call;
 	private String callReason;
 	
-	private double probability;
-	private double confidence;
+	private double probability = 0.5;
+	private double confidence = 0.5;
 	
 	
 	public CombinedClusterPredictor(List<CombinedPredictor> lcp) {
@@ -69,7 +69,7 @@ public class CombinedClusterPredictor implements InterfaceTypePredictor {
 	}
 
 	@Override
-	public double getScore1() {		
+	public double getScore1() {
 		return SCORE_UNASSIGNED;
 	}
 
@@ -93,7 +93,7 @@ public class CombinedClusterPredictor implements InterfaceTypePredictor {
 			confidence = 1 - probability;
 			break;
 		case NO_PREDICTION: 
-			confidence = CONFIDENCE_UNASSIGNED;
+			confidence = 0.5;
 		
 		}
 		

--- a/eppic-cli/src/main/java/eppic/predictors/CombinedPredictor.java
+++ b/eppic-cli/src/main/java/eppic/predictors/CombinedPredictor.java
@@ -47,8 +47,8 @@ public class CombinedPredictor implements InterfaceTypePredictor {
 	
 	private CallType call;
 	
-	private double probability;
-	private double confidence;
+	private double probability = 0.5;
+	private double confidence = 0.5;
 	
 	public CombinedPredictor(InterfaceEvolContext iec, 
 			GeometryPredictor gp, EvolCoreRimPredictor ecrp, EvolCoreSurfacePredictor ecsp) {
@@ -106,7 +106,7 @@ public class CombinedPredictor implements InterfaceTypePredictor {
 			LOGGER.info("Interface {} is not protein in either side, can't score it",iec.getInterface().getId());
 			callReason = "Both sides are not protein, can't score";
 			call = CallType.NO_PREDICTION;
-			probability = -1;
+			probability = 0.5;
 			return;
 		}
 		
@@ -186,7 +186,7 @@ public class CombinedPredictor implements InterfaceTypePredictor {
 			confidence = 1 - probability;
 			break;
 		case NO_PREDICTION:
-			confidence = CONFIDENCE_UNASSIGNED;
+			confidence = 0.5;
 		
 		}
 		

--- a/eppic-cli/src/main/java/eppic/predictors/CombinedPredictor.java
+++ b/eppic-cli/src/main/java/eppic/predictors/CombinedPredictor.java
@@ -115,12 +115,16 @@ public class CombinedPredictor implements InterfaceTypePredictor {
 		
 		// 1) BIO call
 		if (probability > 0.5) {
-			callReason = String.format("P(BIO) = %.2f > 0.5", probability);
+			callReason = String.format(
+					"Probability of the interface being biologically relevant is %.2f.",
+					probability);
 			call = CallType.BIO;
 		} 
 		// 2) XTAL call
 		else if (probability <= 0.5) {
-			callReason = String.format("P(BIO) = %.2f < 0.5", probability);
+			callReason = String.format(
+					"Probability of the interface being biologically relevant is %.2f.",
+					probability);
 			call = CallType.CRYSTAL;
 		}
 		


### PR DESCRIPTION
I changed the final call reason for interfaces as described in #158.
I also set the unassigned value of probability scores to 0.5.
I also implemented a first solution for breaking ties in the highest scoring assemblies of a crystal. Discussion in #161.