### PR TITLE
Normalize assemblies scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 ${sys:logFilename}
 .idea/
 *.iml
+.metadata

--- a/eppic-cli/src/main/java/eppic/EppicParams.java
+++ b/eppic-cli/src/main/java/eppic/EppicParams.java
@@ -235,6 +235,13 @@ public class EppicParams {
 	public static final double LOGIT_CS_NOPRED = - LOGIT_INTERSECT / 
 			(LOGIT_NUM_FEATURES * LOGIT_CS_COEFFICIENT);
 	
+	/**
+	 * The minimum sum of assembly scores required to apply normalization. 
+	 * Scores lower than this value might indicate problems with scoring or
+	 * assembly generation, so a warning will also be shown.
+	 */
+	public static final double MIN_TOTAL_ASSEMBLY_SCORE = 0.2;
+	
 	// Probability thresholds for the WUI call confidence stars
 	/** Calls with probabilities higher than this value are considered high confidence */
 	public static final double HIGH_PROB_CONFIDENCE = 0.95;

--- a/eppic-cli/src/main/java/eppic/assembly/CrystalAssemblies.java
+++ b/eppic-cli/src/main/java/eppic/assembly/CrystalAssemblies.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import eppic.CallType;
+import eppic.EppicParams;
 import eppic.InterfaceEvolContextList;
 
 /**
@@ -615,14 +616,14 @@ public class CrystalAssemblies implements Iterable<Assembly> {
 		}
 		
 		// Warn if low probability density of valid assemblies
-		if (sumProbs < 0.5) {
+		if (sumProbs < EppicParams.MIN_TOTAL_ASSEMBLY_SCORE) {
 			logger.warn("The total probability of valid assemblies is only {}. "
 					+ "Assembly ennumeration may be incomplete.", String.format("%.2f", sumProbs));
+		} else {
+			// Normalize the scores so that they sum up to the total of 1
+			for (Assembly a:uniques)
+				a.normalizeScore(sumProbs);
 		}
-		
-		// Do not normalize the score (easy to do afterwards in the DB though)
-		//for (Assembly a:uniques)
-		//	a.normalizeScore(sumProbs);
 		
 		// 3 Assign the BIO call to the highest probability
 		if (uniques.size() > 0) {


### PR DESCRIPTION
The normalization ensures that scores of valid assemblies sum up to 1. 
A minimum total probability of 0.2 has been set to avoid giving a high probability to assemblies with an initial low score.

Follow up to PR #150 